### PR TITLE
fix: missing prepare-dev in interactive-blocks-react

### DIFF
--- a/packages/interactive-blocks-react/package.json
+++ b/packages/interactive-blocks-react/package.json
@@ -16,6 +16,7 @@
     "build": "tsc",
     "dev": "tsc -w",
     "start": "run-p dev start:example",
+    "prepare-dev": "[ -d dist ] || npm run build",
     "start:example": "cd ../example-react-simple && npm start"
   },
   "dependencies": {


### PR DESCRIPTION
`interactive-blocks-react` pacakge miss the `prepare-dev` command. 

If you run the following command on a brand new project,
```
pnpm i 
npm run dev
```
the build command will fail.

This pull request fixed this problem.